### PR TITLE
Fulfilled remaining user stories

### DIFF
--- a/src/previewer/Editor.js
+++ b/src/previewer/Editor.js
@@ -18,7 +18,14 @@ class Editor extends React.Component {
     });
   }
 
+  componentDidMount() {}
+
   render() {
+    marked.setOptions({
+      gfm: true,
+      breaks: true,
+    });
+
     const rawHtml = marked(this.state.input);
     const parsedHtml = html(rawHtml);
 
@@ -32,6 +39,7 @@ class Editor extends React.Component {
           onChange={this.handleInput}></textarea>
         <br />
         <div id="preview">{parsedHtml}</div>
+        {/* <div id="preview" dangerouslySetInnerHTML={{ __html: rawHtml }}></div> */}
       </div>
     );
   }

--- a/src/previewer/markdown.js
+++ b/src/previewer/markdown.js
@@ -1,5 +1,5 @@
 const markdown = `
-# Youth & Time
+# Youth and Time
 
 ![Cover image](https://null-assetz.netlify.app/images/art/24072021-youth-and-time.png)
 
@@ -17,8 +17,6 @@ I had learnt the tune
 of Solomon's song of vanity  
 and near the ocean did dream bright
 
----
-
 ## First phase
 
 half a sun dance  
@@ -30,8 +28,6 @@ a palace of dreams and contemplation
 I wrote in many names  
 \`changing ... as the wind blew\`  
 I danced in many flames
-
----
 
 ## Love is war
 
@@ -47,8 +43,6 @@ she taught me love
 
 > & that it was war
 
----
-
 ## Dimensions
 
 1. Digital art
@@ -57,8 +51,6 @@ she taught me love
 
 all above I dine with  
 each night when I dream of glory
-
----
 
 ## The schema
 

--- a/src/previewer/markdown.js
+++ b/src/previewer/markdown.js
@@ -41,7 +41,7 @@ with skin like the hands of time
 she liked the colour of my mind
 
 [I was pained when it ended](https://ilovedred.netlify.app/).  
-a fornight of bliss and changes,  
+a fortnight of bliss and changes,  
 a lifetime of scars, unbandaged  
 she taught me love
 


### PR DESCRIPTION
> User Story #6

When my markdown previewer first loads, the default markdown in the #editor field should be rendered as HTML in the #preview element.

> Optional Bonus 

(you do not need to make this test pass): My markdown previewer interprets carriage returns and renders them as br (line break) elements.